### PR TITLE
Containerised the converter app with Docker, for deployment to cluster with Argocd.

### DIFF
--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+
+## Build
+FROM python:3.8-slim-buster
+
+WORKDIR /app
+
+COPY requirments.txt requirements.txt
+
+RUN pip3 install -r requirements.txt
+
+RUN mkdir -p static/uploads static/output
+
+COPY . .
+
+CMD [ "python3", "-m" , "flask", "run", "--host=0.0.0.0"]

--- a/Server/deploy/converter-service-deploy.yaml
+++ b/Server/deploy/converter-service-deploy.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: converter-service-app
+  labels:
+    app: ConverterServiceApp
+    app.kubernetes.io/name: converter-service-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: converter-service-app
+      app.kubernetes.io/name: converter-service-app
+  template:
+    metadata:
+      labels:
+        app: converter-service-app
+        app.kubernetes.io/name: converter-service-app
+    spec:
+      containers:
+      - name: converter-service-app
+        image: mjjos1/converter-service:0.9.0
+        ports:
+        - containerPort: 5000

--- a/Server/deploy/converter-service-svc.yaml
+++ b/Server/deploy/converter-service-svc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: converter-service-app
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: converter-service-app
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 5000

--- a/Server/requirments.txt
+++ b/Server/requirments.txt
@@ -7,7 +7,6 @@ Jinja2==3.1.2
 lxml==4.9.1
 MarkupSafe==2.1.1
 openpyxl==3.0.10
-python-apt==2.0.0+ubuntu0.20.4.8
 python-docx==0.8.11
 Werkzeug==2.2.2
 zipp==3.8.1


### PR DESCRIPTION
@louissullivan4 , the docker build kept failing on the `pip install` of `python-apt` (I think it fails because the base Docker image is Python 3 rather than 2), so I removed it thinking it would not be needed in the container, and indeed it worked fine without it.

I've tested all the below, and it works correctly when manually deployed to the Cluster without Argocd.